### PR TITLE
Initialize project skeleton

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['airbnb', 'airbnb/hooks', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  plugins: ['@typescript-eslint'],
+  env: {
+    browser: true,
+    es2021: true,
+    jest: true
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000'
+  }
+});

--- a/cypress/integration/sample.cy.ts
+++ b/cypress/integration/sample.cy.ts
@@ -1,0 +1,7 @@
+// TODO: add end-to-end tests
+
+describe('Home', () => {
+  it('loads successfully', () => {
+    cy.visit('/');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect']
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "ogd-design-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "zustand": "latest",
+    "axios": "latest",
+    "react-grid-layout": "latest",
+    "d3": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest",
+    "eslint": "latest",
+    "eslint-config-airbnb": "latest",
+    "eslint-config-prettier": "latest",
+    "eslint-plugin-react": "latest",
+    "prettier": "latest",
+    "jest": "latest",
+    "ts-jest": "latest",
+    "@testing-library/react": "latest",
+    "@testing-library/jest-dom": "latest",
+    "cypress": "latest"
+  }
+}

--- a/src/adapters/apiAdapter.ts
+++ b/src/adapters/apiAdapter.ts
@@ -1,0 +1,3 @@
+export function normalizeApiResponse(response: unknown) {
+  // TODO: normalize API response into FeatureSet
+}

--- a/src/adapters/tsvAdapter.ts
+++ b/src/adapters/tsvAdapter.ts
@@ -1,0 +1,3 @@
+export function parseTSV(data: string) {
+  // TODO: implement TSV parsing
+}

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const BarChart: React.FC = () => {
+  return <div>{/* TODO: D3 bar chart implementation */}</div>;
+};

--- a/src/components/charts/ForceGraph.tsx
+++ b/src/components/charts/ForceGraph.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ForceGraph: React.FC = () => {
+  return <div>{/* TODO: D3 force graph implementation */}</div>;
+};

--- a/src/components/charts/Histogram.tsx
+++ b/src/components/charts/Histogram.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Histogram: React.FC = () => {
+  return <div>{/* TODO: D3 histogram implementation */}</div>;
+};

--- a/src/components/charts/ScatterPlot.tsx
+++ b/src/components/charts/ScatterPlot.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const ScatterPlot: React.FC = () => {
+  return <div>{/* TODO: D3 scatter plot implementation */}</div>;
+};

--- a/src/components/charts/Timeline.tsx
+++ b/src/components/charts/Timeline.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Timeline: React.FC = () => {
+  return <div>{/* TODO: D3 timeline implementation */}</div>;
+};

--- a/src/components/layout/GridLayout.tsx
+++ b/src/components/layout/GridLayout.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const GridLayout: React.FC = ({ children }) => {
+  return <div>{/* TODO: react-grid-layout wrapper */}{children}</div>;
+};
+
+export default GridLayout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,8 @@
+import type { AppProps } from 'next/app';
+import React from 'react';
+
+const MyApp = ({ Component, pageProps }: AppProps) => {
+  return <Component {...pageProps} />;
+};
+
+export default MyApp;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const HomePage: React.FC = () => {
+  return (
+    <div>
+      <h1>Field Day Lab Dashboard</h1>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function fetchFromApi(url: string) {
+  // TODO: fetch data using axios and handle caching
+  return axios.get(url);
+}

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -1,0 +1,7 @@
+export function getCachedData(key: string) {
+  // TODO: implement cache lookup with TTL
+}
+
+export function setCachedData(key: string, data: unknown, ttl: number) {
+  // TODO: implement cache write
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,0 +1,9 @@
+import create from 'zustand';
+
+interface State {
+  /* TODO: define state shape */
+}
+
+export const useStore = create<State>(() => ({
+  // TODO: initialize state
+}));

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export interface FeatureSet {
+  // TODO: define common data structure for charts
+}

--- a/tests/sample.test.tsx
+++ b/tests/sample.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import HomePage from '../src/pages/index';
+
+test('renders header', () => {
+  const { getByText } = render(<HomePage />);
+  expect(getByText('Field Day Lab Dashboard')).toBeInTheDocument();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js/TypeScript skeleton with placeholder pages
- scaffold chart components, adapters, services, and Zustand store
- set up Jest, Cypress, ESLint, and Prettier configurations

## Testing
- `npm test` *(fails: jest not installed)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6859891747ac832d884df3329838688b