### PR TITLE
Switch storage to IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "d3": "latest",
         "d3-regression": "^1.3.10",
         "d3-sankey": "^0.12.3",
+        "idb": "latest",
         "lucide-react": "^0.523.0",
         "next": "latest",
         "react": "latest",
@@ -6824,6 +6825,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="
     },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "latest",
     "react-dom": "latest",
     "react-grid-layout": "^1.5.1",
-    "zustand": "latest"
+    "zustand": "latest",
+    "idb": "latest"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/src/components/data-management/DataSourceList.tsx
+++ b/src/components/data-management/DataSourceList.tsx
@@ -3,12 +3,16 @@ import FilePicker from './FilePicker';
 import { X } from 'lucide-react';
 
 const DataSourceList = () => {
-  const { datasets, removeDataset } = useDataStore();
+  const { datasets, removeDataset, hasHydrated } = useDataStore();
 
   return (
     <div className="flex flex-col gap-4 overflow-y-auto">
       <FilePicker />
-      {Object.keys(datasets).length > 0 && (
+      {!hasHydrated && <div>Loading datasets...</div>}
+      {hasHydrated && Object.keys(datasets).length === 0 && (
+        <div className="text-sm text-gray-500">No datasets loaded</div>
+      )}
+      {hasHydrated && Object.keys(datasets).length > 0 && (
         <div className="flex flex-col gap-2 overflow-clip">
           {Object.values(datasets).map((dataset) => (
             <div

--- a/src/components/viz/VizSetup.tsx
+++ b/src/components/viz/VizSetup.tsx
@@ -19,21 +19,23 @@ const VizSetup = ({
   setVizType,
   setContainerMode,
 }: VizSetupProps) => {
-  const { datasets } = useDataStore();
+  const { datasets, hasHydrated } = useDataStore();
   const [supportedChartTypes, setSupportedChartTypes] = useState<VizTypeKey[]>(
     [],
   );
 
   useEffect(() => {
     if (!gameDataId) return;
-    const supportedChartTypes = datasets[gameDataId].supportedChartTypes;
+    const dataset = datasets[gameDataId];
+    if (!dataset) return;
+    const supportedChartTypes = dataset.supportedChartTypes;
     if (supportedChartTypes) {
       setSupportedChartTypes(supportedChartTypes);
     }
     if (!supportedChartTypes.includes(vizType)) {
       setVizType(supportedChartTypes[0]);
     }
-  }, [gameDataId]);
+  }, [gameDataId, datasets]);
 
   const visualize = () => {
     if (gameDataId) {
@@ -43,13 +45,14 @@ const VizSetup = ({
 
   return (
     <div className="h-full flex flex-col gap-6 justify-center items-start p-4">
+      {!hasHydrated && <div>Loading datasets...</div>}
       <Select
         className="w-full"
         label="Dataset"
         value={gameDataId}
         onChange={(value) => setGameDataId(value as string)}
         options={Object.fromEntries(
-          Object.entries(datasets).map(([key, value]) => [key, key]),
+          Object.entries(datasets).map(([key]) => [key, key]),
         )}
       />
       <Select

--- a/src/components/viz/charts/BarChart.tsx
+++ b/src/components/viz/charts/BarChart.tsx
@@ -10,8 +10,9 @@ interface BarChartProps {
 }
 
 export const BarChart: React.FC<BarChartProps> = ({ gameDataId }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
   const [feature, setFeature] = useState<string>('');
   const [filter, setFilter] = useState<string[]>([]);

--- a/src/components/viz/charts/BoxPlot.tsx
+++ b/src/components/viz/charts/BoxPlot.tsx
@@ -9,8 +9,9 @@ interface BoxPlotProps {
 }
 
 const BoxPlot: React.FC<BoxPlotProps> = ({ gameDataId }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
 
   const [feature, setFeature] = useState<string>('');

--- a/src/components/viz/charts/DescriptiveStatistics.tsx
+++ b/src/components/viz/charts/DescriptiveStatistics.tsx
@@ -19,8 +19,9 @@ const measures = {
 const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
   gameDataId,
 }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
   const [feature, setFeature] = useState<string>('');
   const [measureSelected, setMeasureSelected] =

--- a/src/components/viz/charts/Histogram.tsx
+++ b/src/components/viz/charts/Histogram.tsx
@@ -11,8 +11,9 @@ interface HistogramProps {
 }
 
 export const Histogram: React.FC<HistogramProps> = ({ gameDataId }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
   const [feature, setFeature] = useState<string>('');
   const [binCount, setBinCount] = useState<number>(10);

--- a/src/components/viz/charts/JobGraph.tsx
+++ b/src/components/viz/charts/JobGraph.tsx
@@ -10,8 +10,9 @@ interface JobGraphProps {
 }
 
 export const JobGraph: React.FC<JobGraphProps> = ({ gameDataId }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
 
   const [edgeMode, setEdgeMode] = useState<keyof typeof EdgeMode>(

--- a/src/components/viz/charts/Sankey.tsx
+++ b/src/components/viz/charts/Sankey.tsx
@@ -33,8 +33,9 @@ interface SankeyData {
 }
 
 export const Sankey: React.FC<SankeyProps> = ({ gameDataId }) => {
-  const dataset = useDataStore().getDatasetByID(gameDataId);
-  if (!dataset) return <div>Dataset not found</div>;
+  const { getDatasetByID, hasHydrated } = useDataStore();
+  const dataset = getDatasetByID(gameDataId);
+  if (!dataset) return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   const { data } = dataset;
 
   const [edgeMode, setEdgeMode] = useState<keyof typeof EdgeMode>(

--- a/src/components/viz/charts/ScatterPlot.tsx
+++ b/src/components/viz/charts/ScatterPlot.tsx
@@ -24,7 +24,7 @@ const RegressionLineType = {
 } as const;
 
 export const ScatterPlot: React.FC<ScatterPlotProps> = ({ gameDataId }) => {
-  const { getDatasetByID } = useDataStore();
+  const { getDatasetByID, hasHydrated } = useDataStore();
   const dataset = getDatasetByID(gameDataId);
   const [xFeature, setXFeature] = useState<string>('');
   const [xRangeFilter, setXRangeFilter] = useState<{
@@ -54,7 +54,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ gameDataId }) => {
   }, [yFeature]);
 
   if (!dataset) {
-    return <div>Dataset not found</div>;
+    return hasHydrated ? <div>Dataset not found</div> : <div>Loading dataset...</div>;
   }
   const { data } = dataset;
 

--- a/src/store/useDataStore.ts
+++ b/src/store/useDataStore.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
 import { persist, PersistStorage } from 'zustand/middleware';
+import { openDB } from 'idb';
 
 interface DataStore {
   // states
   datasets: Record<string, GameData>;
+  hasHydrated: boolean;
   // actions
   addDataset: (dataset: GameData) => void;
   removeDataset: (id: string) => void;
@@ -16,75 +18,44 @@ interface DataStore {
   ) => GameData[];
 }
 
-// Custom storage with error handling and size limits
-const customStorage: PersistStorage<DataStore> = {
-  getItem: (name: string) => {
+// IndexedDB storage for larger datasets
+const dbPromise = openDB('ogd-data-store', 1, {
+  upgrade(db) {
+    db.createObjectStore('store');
+  },
+});
+
+const idbStorage: PersistStorage<DataStore> = {
+  getItem: async (name: string) => {
     try {
-      const item = localStorage.getItem(name);
+      const db = await dbPromise;
+      const item = await db.get('store', name);
       console.log(
-        '🔍 Attempting to load from localStorage:',
+        '🔍 Attempting to load from idb:',
         name,
         item ? 'Found data' : 'No data found',
       );
-      if (item) {
-        const parsed = JSON.parse(item);
-        console.log('📦 Loaded data:', parsed);
-        return parsed;
-      }
-      return null;
+      return item ?? null;
     } catch (error) {
-      console.warn('Failed to read from localStorage:', error);
+      console.warn('Failed to read from idb:', error);
       return null;
     }
   },
-  setItem: (name: string, value: any) => {
+  setItem: async (name: string, value: any) => {
     try {
-      const valueString = JSON.stringify(value);
-      console.log(
-        '💾 Attempting to save to localStorage:',
-        name,
-        'Size:',
-        new Blob([valueString]).size,
-        'bytes',
-      );
-
-      // Check if data is too large (localStorage typically has 5-10MB limit)
-      const sizeInBytes = new Blob([valueString]).size;
-      const sizeInMB = sizeInBytes / (1024 * 1024);
-
-      if (sizeInMB > 4) {
-        // 4MB limit to be safe
-        console.warn('Data too large for localStorage, skipping persistence');
-        return;
-      }
-
-      localStorage.setItem(name, valueString);
-      console.log('✅ Successfully saved to localStorage');
+      const db = await dbPromise;
+      await db.put('store', value, name);
+      console.log('✅ Successfully saved to idb');
     } catch (error) {
-      if (error instanceof Error && error.name === 'QuotaExceededError') {
-        console.warn(
-          'localStorage quota exceeded, clearing old data and retrying',
-        );
-        try {
-          // Clear all localStorage and retry
-          localStorage.clear();
-          localStorage.setItem(name, JSON.stringify(value));
-        } catch (retryError) {
-          console.error(
-            'Failed to persist data even after clearing localStorage:',
-            retryError,
-          );
-        }
-      } else {
-        console.error('Failed to write to localStorage:', error);
-      }
+      console.error('Failed to write to idb:', error);
     }
   },
-  removeItem: (name: string) => {
+  removeItem: async (name: string) => {
     try {
-      localStorage.removeItem(name);
+      const db = await dbPromise;
+      await db.delete('store', name);
     } catch (error) {
-      console.warn('Failed to remove from localStorage:', error);
+      console.warn('Failed to remove from idb:', error);
     }
   },
 };
@@ -94,6 +65,7 @@ const useDataStore = create<DataStore>()(
     (set, get) => ({
       // states
       datasets: {},
+      hasHydrated: false,
       // actions
       addDataset: (dataset: GameData) => {
         console.log('➕ Adding dataset:', dataset.id);
@@ -128,7 +100,10 @@ const useDataStore = create<DataStore>()(
     {
       name: 'ogd-data-store',
       version: 1,
-      storage: customStorage,
+      storage: idbStorage,
+      onRehydrateStorage: () => () => {
+        set({ hasHydrated: true });
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- persist datasets to IndexedDB using `idb`
- show dataset loading state in DataSourceList and charts
- adjust VizSetup to handle async store hydration
- add `idb` as a dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ce5ecfd4832db083adf1691d4c93