### PR TITLE
Google analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Google Analytics 4 Measurement ID (e.g. G-XXXXXXXXXX)
+# Add to .env.local for local development. Omit or leave empty to disable analytics.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 .next
 coverage
 .DS_Store
+.env
+.env.local
 
 # folders
 /.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 .DS_Store
 .env
 .env.local
+tsconfig.tsbuildinfo
 
 # folders
 /.cursor/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Field Day Lab processes rich gameplay data—population, session, and player fea
 
 Make sure you have node v22.17.1 (or newer) and npm v10.9.2 (or newer) install on your machine.
 
+Copy `.env.example` to `.env.local` and optionally add your Google Analytics measurement ID (`NEXT_PUBLIC_GA_MEASUREMENT_ID`) for usage tracking. Analytics only runs in production when the ID is set.
+
 Install relevant npm packages:
 `npm install`
 

--- a/src/components/layout/GridLayout.tsx
+++ b/src/components/layout/GridLayout.tsx
@@ -6,6 +6,7 @@ import VizContainer from './VizContainer';
 import { v4 as uuidv4 } from 'uuid';
 import useLayoutStore from '../../store/useLayoutStore';
 import { Plus, Wrench } from 'lucide-react';
+import { trackEvent } from '../../lib/analytics';
 
 const MAX_COLS = 12;
 const DEFAULT_CHART_WIDTH = 4;
@@ -130,6 +131,7 @@ const GridLayout: React.FC = () => {
     ];
     saveCurrentLayout(newLayout, newCharts);
     updateSpawnPoint(newLayout);
+    trackEvent('chart_added');
   };
 
   const removeChart = (chartId: string) => {

--- a/src/components/layout/select/FeatureSelect.tsx
+++ b/src/components/layout/select/FeatureSelect.tsx
@@ -1,5 +1,6 @@
 import SearchableSelect from './SearchableSelect';
 import { useMemo, useState, useEffect } from 'react';
+import { trackEvent } from '../../../lib/analytics';
 
 interface FeatureSelectProps {
   feature: string;
@@ -21,6 +22,10 @@ export default function FeatureSelect({
 }: FeatureSelectProps) {
   const [selectedBaseFeature, setSelectedBaseFeature] = useState<string>('');
   const [selectedIteration, setSelectedIteration] = useState<string>('');
+
+  const emitFeatureSelected = (selectedFeature: string) => {
+    trackEvent('feature_selected', { feature: selectedFeature });
+  };
 
   // Parse features into simple and iterated categories
   const parsedFeatures: ParsedFeatures = useMemo(() => {
@@ -66,7 +71,9 @@ export default function FeatureSelect({
       const defaultIteration =
         parsedFeatures.iteratedFeatures[selectedBaseFeature][0] || '';
       setSelectedIteration(defaultIteration);
-      handleFeatureChange(`${defaultIteration}_${selectedBaseFeature}`);
+      const selectedFeature = `${defaultIteration}_${selectedBaseFeature}`;
+      emitFeatureSelected(selectedFeature);
+      handleFeatureChange(selectedFeature);
     }
   }, [selectedBaseFeature, selectedIteration, parsedFeatures]);
 
@@ -87,13 +94,16 @@ export default function FeatureSelect({
 
     // If it's a simple feature, directly call the handler
     if (parsedFeatures.simpleFeatures.includes(baseFeature)) {
+      emitFeatureSelected(baseFeature);
       handleFeatureChange(baseFeature);
     }
   };
 
   const handleIterationChange = (iteration: string) => {
     setSelectedIteration(iteration);
-    handleFeatureChange(`${iteration}_${selectedBaseFeature}`);
+    const selectedFeature = `${iteration}_${selectedBaseFeature}`;
+    emitFeatureSelected(selectedFeature);
+    handleFeatureChange(selectedFeature);
   };
 
   return (

--- a/src/components/sidebar/LayoutManager.tsx
+++ b/src/components/sidebar/LayoutManager.tsx
@@ -5,6 +5,7 @@ import useLayoutStore, {
 import useDataStore from '../../store/useDataStore';
 import { useState } from 'react';
 import Input from '../layout/Input';
+import { trackEvent } from '../../lib/analytics';
 
 const LayoutManager = () => {
   const {
@@ -22,6 +23,7 @@ const LayoutManager = () => {
   const [editingName, setEditingName] = useState('');
 
   const handleCreate = () => {
+    trackEvent('dashboard_created');
     createLayout();
   };
 
@@ -69,6 +71,7 @@ const LayoutManager = () => {
     a.download = `${layout.name}.json`;
     a.click();
     URL.revokeObjectURL(url);
+    trackEvent('layout_export');
   };
 
   return (
@@ -89,7 +92,10 @@ const LayoutManager = () => {
             className={`p-3 hover:bg-blue-50 rounded-lg border border-gray-100 transition-colors ${
               currentLayout === id ? 'bg-blue-100' : 'bg-gray-50'
             }`}
-            onClick={() => setCurrentLayout(id)}
+            onClick={() => {
+              setCurrentLayout(id);
+              trackEvent('dashboard_switch', { layout_id: id, layout_name: layout.name });
+            }}
           >
             <div className="w-full flex justify-between items-center gap-2">
               {editingId === id ? (

--- a/src/components/sidebar/data-management/DatasetAPIPicker.tsx
+++ b/src/components/sidebar/data-management/DatasetAPIPicker.tsx
@@ -10,6 +10,7 @@ import {
   normalizeApiResponse,
 } from '../../../adapters/apiAdapter';
 import { X } from 'lucide-react';
+import { trackEvent } from '../../../lib/analytics';
 
 const DatasetAPIPicker = () => {
   const { addDataset, hasDataset } = useDataStore();
@@ -76,14 +77,16 @@ const DatasetAPIPicker = () => {
       api.getDataset(game, dataset.split('/')[1], dataset.split('/')[0], level),
     onSuccess: (responseBody, variables) => {
       if (responseBody) {
-        addDataset(
-          normalizeApiResponse(
-            responseBody,
-            variables.game,
-            variables.dataset,
-            variables.level,
-          ),
+        const dataset = normalizeApiResponse(
+          responseBody,
+          variables.game,
+          variables.dataset,
+          variables.level,
         );
+        addDataset(dataset);
+        trackEvent('dataset_added_via_api', {
+          dataset_id: dataset.id,
+        });
       }
     },
     onSettled: (data, error, variables) => {
@@ -116,6 +119,9 @@ const DatasetAPIPicker = () => {
     level: 'population' | 'player' | 'session';
   }) => {
     const isImporting = importingLevels.has(level);
+    const isImported = hasDataset(
+      generateAPIDatasetID(selectedGame, selectedDataset, level),
+    );
     return (
       <div
         key={level}
@@ -142,13 +148,11 @@ const DatasetAPIPicker = () => {
               generateAPIDatasetID(selectedGame, selectedDataset, level),
             )
           }
-          className="w-full bg-blue-400 text-white px-4 py-2 rounded-md font-medium cursor-pointer shadow hover:bg-blue-500 transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          className={`w-full ${isImported ? 'bg-gray-400' : 'bg-blue-400 hover:bg-blue-500'} text-white px-4 py-2 rounded-md font-medium cursor-pointer shadow transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed`}
         >
           {isImporting
             ? 'Importing...'
-            : hasDataset(
-                  generateAPIDatasetID(selectedGame, selectedDataset, level),
-                )
+            : isImported
               ? 'Imported'
               : 'Add to Dashboard'}
         </button>

--- a/src/components/sidebar/data-management/DatasetTSVPicker.tsx
+++ b/src/components/sidebar/data-management/DatasetTSVPicker.tsx
@@ -2,6 +2,7 @@ import { Upload } from 'lucide-react';
 import { useRef } from 'react';
 import useDataStore from '../../../store/useDataStore';
 import { parseTSV } from '../../../adapters/tsvAdapter';
+import { trackEvent } from '../../../lib/analytics';
 
 const DatasetTSVPicker = () => {
   const { addDataset } = useDataStore();
@@ -36,6 +37,9 @@ const DatasetTSVPicker = () => {
         console.log('Processing file:', file.name);
         const dataset = await parseTSV(file);
         addDataset(dataset);
+        trackEvent('dataset_added_via_tsv', {
+          dataset_id: dataset.id,
+        });
       }
     } catch (error) {
       console.error('Error parsing TSV file:', error);

--- a/src/components/viz/VizSetup.tsx
+++ b/src/components/viz/VizSetup.tsx
@@ -4,6 +4,7 @@ import useDataStore from '../../store/useDataStore';
 import Select from '../layout/select/Select';
 import { VizType, VizTypeKey } from '../../constants/vizTypes';
 import Input from '../layout/Input';
+import { trackEvent } from '../../lib/analytics';
 
 interface VizSetupProps {
   gameDataIds: string[];
@@ -49,6 +50,11 @@ const VizSetup = ({
   }, [gameDataIds, datasets]);
 
   const visualize = () => {
+    trackEvent('chart_applied', {
+      viz_type: vizType,
+      dataset_id: gameDataIds.join(', '),
+    });
+    
     if (gameDataIds.length) {
       setContainerMode('viz');
     }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,22 @@
+/**
+ * Analytics helpers for Google Analytics 4 (gtag.js).
+ * All functions no-op when gtag is not available (e.g. measurement ID not set, SSR).
+ */
+
+export function trackEvent(
+  action: string,
+  params?: Record<string, string | number | boolean>,
+): void {
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', action, params);
+  }
+}
+
+export function pageView(url: string): void {
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    if (measurementId) {
+      window.gtag('config', measurementId, { page_path: url });
+    }
+  }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,54 @@
 import type { AppProps } from 'next/app';
-import React from 'react';
+import React, { useEffect } from 'react';
+import Script from 'next/script';
+import { useRouter } from 'next/router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { pageView } from '../lib/analytics';
 import '../styles/globals.css';
 
 const queryClient = new QueryClient();
 
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const GA_ENABLED =
+  GA_MEASUREMENT_ID && process.env.NODE_ENV === 'production';
+
 const MyApp = ({ Component, pageProps }: AppProps) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!GA_ENABLED) return;
+
+    const handleRouteChange = (url: string) => {
+      pageView(url);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    handleRouteChange(router.asPath);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.asPath, router.events]);
+
   return (
     <QueryClientProvider client={queryClient}>
+      {GA_ENABLED && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="gtag-init" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              window.gtag = gtag;
+              gtag('js', new Date());
+              gtag('config', '${GA_MEASUREMENT_ID}');
+            `}
+          </Script>
+        </>
+      )}
       <Component {...pageProps} />
     </QueryClientProvider>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import DatasetDeepLinkProvider from '../components/providers/DatasetDeepLinkProv
 import { Upload } from 'lucide-react';
 import useDataStore from '../store/useDataStore';
 import useLayoutStore from '../store/useLayoutStore';
+import { trackEvent } from '../lib/analytics';
 
 const HomePage: React.FC = () => {
   const [activeTab, setActiveTab] = useState(0);
@@ -39,10 +40,12 @@ const HomePage: React.FC = () => {
             datasets: { ...state.datasets, ...importData.datasets },
           }));
         }
+        trackEvent('layout_import');
       } else {
         // Legacy format - use old method
         const layout = loadLayout(importJson);
         setCurrentLayout(layout.id);
+        trackEvent('layout_import');
       }
     };
     fileReader.readAsText(file);

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,6 +1,9 @@
 import * as d3 from 'd3';
 
 declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
   interface GameData {
     id: string;
     game: string;


### PR DESCRIPTION
# Google Analytics Integration Plan

## Current State

- No existing analytics or gtag code in the repo
- App entry: `[src/pages/_app.tsx](src/pages/_app.tsx)` wraps all pages with `QueryClientProvider`
- Next.js 15 with Pages Router
- No `_document.tsx` (uses Next.js default)

## Approach

Use **Next.js `Script` component** with `strategy="afterInteractive"` to load gtag.js. This avoids blocking initial render and follows [Next.js recommended patterns](https://nextjs.org/docs/app/building-your-application/optimizing/scripts) for third-party scripts. Inject the script and a small GA helper in `_app.tsx`, and optionally add a thin analytics module for custom events.

---

## Implementation Steps

### 1. Environment Configuration

Add support for the GA measurement ID via an env var so it can differ per environment:

- **Variable:** `NEXT_PUBLIC_GA_MEASUREMENT_ID` (e.g. `G-XXXXXXXXXX`)
- **Rationale:** `NEXT_PUBLIC_` prefix exposes it to the browser, which is required for gtag
- **Document:** Add `.env.example` with `NEXT_PUBLIC_GA_MEASUREMENT_ID=` and note it in README under "Running the App"
- **Behavior:** When the ID is missing or in `NODE_ENV=development`, GA calls will be no-ops to avoid polluting production data

### 2. Load gtag Script and Bootstrap GA

In `[src/pages/_app.tsx](src/pages/_app.tsx)`:

- Import `Script` from `next/script`
- Add a `<Script>` that:
  - Loads `https://www.googletagmanager.com/gtag/js?id=${NEXT_PUBLIC_GA_MEASUREMENT_ID}`
  - Uses `strategy="afterInteractive"`
  - Runs an inline bootstrap script that creates `dataLayer` and calls `gtag('config', measurementId)`
- Only render the script when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is defined and `NODE_ENV === 'production'` (or a similar flag so dev/local stays clean)

### 3. Page View Tracking

Use `useRouter` from `next/router` in `_app.tsx` to track route changes:

- On `router.events` `routeChangeComplete`, call `gtag('event', 'page_view', { page_path: url })`
- Or use `gtag('config', measurementId, { page_path: router.asPath })` on route change for standard GA4 page_view semantics

This captures all page navigations in the single-page app (including client-side route changes if you add more routes later).

### 4. Analytics Utility Module (Optional but Recommended)

Create `src/lib/analytics.ts` (or `src/utils/analytics.ts`) to centralize GA calls:

```ts
export function trackEvent(action: string, params?: Record<string, string | number | boolean>) {
  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
    window.gtag('event', action, params);
  }
}
```

Add a `gtag` declaration in `[src/types/globals.d.ts](src/types/globals.d.ts)`:

```ts
interface Window {
  gtag?: (...args: unknown[]) => void;
}
```

This keeps all GA logic in one place and makes it easy to stub in tests or disable when the measurement ID is absent.

### 5. Custom Usage Events

For deeper insight into how the dashboard is used, fire custom events at key interactions. Examples:


| Event            | Action Name        | Params                                      |
| ---------------- | ------------------ | ------------------------------------------- |
| Dataset added    | `dataset_added`    | `source` (`file` or `api`), `feature_level` |
| Chart added      | `chart_added`      | `viz_type` (currently `bar` for new charts) |
| Feature selected | `feature_selected` | `feature` (selected feature key)            |
| Dashboard switch | `dashboard_switch` | `layout_id`                                 |
| Layout export    | `layout_export`    | none                                        |
| Layout import    | `layout_import`    | none                                        |


These would call `trackEvent(...)` from the relevant components (e.g. `DataSourceList`, `GridLayout`, `LayoutManager`). Start with page views; add custom events incrementally based on what your team cares about.

`feature_selected` should be emitted in `handleFeatureChange()` call sites in `FeatureSelect` so each feature picker interaction logs the selected feature key.

---

## File Summary


| File                         | Change                                                      |
| ---------------------------- | ----------------------------------------------------------- |
| `src/pages/_app.tsx`         | Add Script, bootstrap gtag, route-change page view tracking |
| `src/lib/analytics.ts` (new) | `trackEvent` helper, `pageView` helper                      |
| `src/types/globals.d.ts`     | Extend `Window` with `gtag`                                 |
| `.env.example` (new)         | `NEXT_PUBLIC_GA_MEASUREMENT_ID=`                            |
| `README.md`                  | Add env var note under "Running the App"                    |


---

## Configuration Needed From Your Team

To complete the setup:

1. **Measurement ID:** The GA4 property ID (e.g. `G-XXXXXXXXXX`). Add it to `.env.local` as `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-...`
2. **Clarification:** If "gtag set up" means **Google Tag Manager (GTM)** instead of direct gtag.js, the implementation changes: you would load the GTM container script and configure tags inside GTM rather than adding gtag.js directly. Confirm whether you use GA4 directly or via GTM.

---

## Diagram: Data Flow

```mermaid
flowchart LR
  subgraph App
    A[_app.tsx]
    A --> B[Script loads gtag.js]
    A --> C[useRouter routeChangeComplete]
    C --> D[gtag page_view]
  end

  subgraph Components
    E[DataSourceList]
    F[GridLayout]
    E --> G[trackEvent]
    F --> G
    G --> D
  end

  D --> H[Google Analytics]
  B --> H
```



---

## Testing Considerations

- Mock or stub `window.gtag` in Jest for components that call `trackEvent`
- Ensure GA script is not loaded when `NEXT_PUBLIC_GA_MEASUREMENT_ID` is unset (e.g. in CI)
- Use GA4 DebugView (Chrome extension or `gtag('config', id, { debug_mode: true })`) to verify events during development

## Local QA Checklist

### Setup

- Run app in prod mode: `npm run build && npm run start`
- Ensure `.env.local` has `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-...`
- Open GA4 DebugView (recommended) or Realtime
- Optional: enable Google Analytics Debugger extension

### Event Checks

- Dataset upload (TSV)
  - Action: Upload a `.tsv` file
  - Expect event: `dataset_added_via_tsv`
  - Expect params: `source: "file"`, `feature_level: "population" | "player" | "session" | "unknown"`
- Dataset import (API)
  - Action: Browse Datasets, choose game/month, click `Add to Dashboard`
  - Expect event: `dataset_added_via_api`
  - Expect params: `source: "api"`, `feature_level: "population" | "player" | "session"`
- Add chart
  - Action: Click `Add Chart`
  - Expect event: `chart_added`
  - Expect params: `viz_type: "bar"`
- Feature selected
  - Action: Change feature via a chart feature selector
  - Expect event: `feature_selected`
  - Expect params: `feature: "<selected_feature_key>"`
- Switch dashboard
  - Action: Click a different dashboard in Dashboards tab
  - Expect event: `dashboard_switch`
  - Expect params: `layout_id: "<uuid>"`
- Export layout
  - Action: Click download icon on a dashboard
  - Expect event: `layout_export`
  - Params: none expected
- Import layout
  - Action: Use Import JSON in side panel
  - Expect event: `layout_import`
  - Params: none expected

### Sanity Checks

- Each action emits exactly one event per click/upload
- Page navigation still emits page views
- In `npm run dev`, events do not send (expected behavior)

