### PR TITLE
Add quartiles measure to descriptive statistics

### DIFF
--- a/src/components/viz/charts/DescriptiveStatistics.tsx
+++ b/src/components/viz/charts/DescriptiveStatistics.tsx
@@ -5,6 +5,10 @@ import useChartOption from '../../../hooks/useChartOption';
 import useDataStore from '../../../store/useDataStore';
 import FeatureSelect from '../../layout/select/FeatureSelect';
 import { CollapsibleChartConfig } from '../CollapsibleChartConfig';
+import {
+  formatStatValue,
+  formatStatValues,
+} from '../../../utils/formatStatValue';
 
 interface DescriptiveStatisticsProps {
   dataset: GameData;
@@ -18,6 +22,7 @@ const measures = {
   median: 'Median',
   mode: 'Mode',
   range: 'Range',
+  quartiles: 'Quartiles',
   variance: 'Variance',
   standardDeviation: 'Std. Dev.',
 };
@@ -46,12 +51,17 @@ const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
     // Calculate the mean, median, mode, range, variance, standard deviation, skewness, and kurtosis
     const count = data.length;
     const unique = new Set(values).size;
-    const mean = d3.mean(values)?.toFixed(2);
+    const mean = d3.mean(values);
     const median = d3.median(values);
     const mode = d3.mode(values);
     const range = d3.extent(values);
-    const variance = d3.variance(values)?.toFixed(2);
-    const standardDeviation = d3.deviation(values)?.toFixed(2);
+    const quartiles = [
+      d3.quantile(values, 0.25),
+      d3.quantile(values, 0.5),
+      d3.quantile(values, 0.75),
+    ];
+    const variance = d3.variance(values);
+    const standardDeviation = d3.deviation(values);
     // const skewness =
     // const kurtosis = d3.kurtosis(values);
 
@@ -62,6 +72,7 @@ const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
       median,
       mode,
       range,
+      quartiles,
       variance,
       standardDeviation,
     };
@@ -88,6 +99,22 @@ const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
     );
   };
 
+  const formatMeasureDisplay = (
+    measure: keyof typeof measures,
+    value: unknown,
+  ): string => {
+    if (
+      (measure === 'range' || measure === 'quartiles') &&
+      Array.isArray(value)
+    ) {
+      return formatStatValues(value);
+    }
+    if (typeof value === 'number') {
+      return formatStatValue(value);
+    }
+    return value != null ? String(value) : '';
+  };
+
   const jumbotron = () => {
     if (!feature) return <></>;
 
@@ -95,9 +122,7 @@ const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
       return (
         <>
           <span className="text-6xl font-bold">
-            {measureSelected === 'range' && stats[measureSelected]
-              ? `${stats[measureSelected][0]} ~ ${stats[measureSelected][1]}`
-              : stats[measureSelected]}
+            {formatMeasureDisplay(measureSelected, stats[measureSelected])}
           </span>
           <span className="text-lg">
             <strong>

--- a/src/utils/formatStatValue.ts
+++ b/src/utils/formatStatValue.ts
@@ -1,0 +1,11 @@
+export function formatStatValue(value: number | undefined | null): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  if (Number.isInteger(value)) return value.toLocaleString();
+  return value.toFixed(2);
+}
+
+export function formatStatValues(
+  values: Array<number | undefined | null>,
+): string {
+  return values.map(formatStatValue).join(' ~ ');
+}


### PR DESCRIPTION
## Summary
- Adds **Quartiles** as a new Measure option in the descriptive statistics chart (Q1, Q2, Q3), addressing #57
- Introduces a shared `formatStatValue` utility for consistent display formatting (integers as-is, continuous stats at 2 decimal places)
- Stores computed stats as raw numbers and formats at display time, matching conventions used in Histogram and BoxPlot

## Test plan
- [ ] Open a chart with descriptive statistics on a numeric feature
- [ ] Select **Quartiles** from the Measure dropdown and verify Q1 ~ Q2 ~ Q3 displays with sensible decimal places
- [ ] Spot-check other measures (mean, median, range, std dev) for consistent 2-decimal formatting
- [ ] Confirm count and unique values still display as integers