### PR TITLE
Fix descriptive statistics config layout for per-count features

### DIFF
--- a/src/components/layout/select/FeatureSelect.tsx
+++ b/src/components/layout/select/FeatureSelect.tsx
@@ -107,9 +107,9 @@ export default function FeatureSelect({
   };
 
   return (
-    <div className="flex gap-2 w-full">
+    <div className="flex flex-wrap gap-2 w-full">
       <SearchableSelect
-        className="w-full min-w-0"
+        className="min-w-0 flex-1 basis-[min(100%,12rem)]"
         label={label}
         placeholder="Select a feature..."
         value={selectedBaseFeature}
@@ -119,6 +119,7 @@ export default function FeatureSelect({
 
       {selectedBaseFeature && hasIterations(selectedBaseFeature) && (
         <SearchableSelect
+          className="min-w-0 flex-1 basis-[min(100%,8rem)]"
           label="Iteration"
           placeholder="Select..."
           value={selectedIteration}

--- a/src/components/viz/charts/DescriptiveStatistics.tsx
+++ b/src/components/viz/charts/DescriptiveStatistics.tsx
@@ -159,7 +159,7 @@ const DescriptiveStatistics: React.FC<DescriptiveStatisticsProps> = ({
             : 'Descriptive Statistics'
         }
       >
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-col gap-2">
           <FeatureSelect
             feature={feature}
             handleFeatureChange={(value) => setFeature(value)}


### PR DESCRIPTION
## Summary
- Stack the Measure control below Feature/Iteration in Descriptive Statistics so it stays within the chart container.
- Allow FeatureSelect to wrap with minimum widths so Feature and Iteration labels no longer overlap in narrow layouts.

Fixes #62.
