### PR TITLE
Alphabetically sort bars in bar chart

### DIFF
--- a/src/components/viz/charts/BarChart.tsx
+++ b/src/components/viz/charts/BarChart.tsx
@@ -153,8 +153,7 @@ export const BarChart: React.FC<BarChartProps> = ({ dataset, chartId }) => {
           return a.value.localeCompare(b.value);
         });
       } else {
-        // For categorical data, sort by count descending
-        chartData.sort((a, b) => b.count - a.count);
+        chartData.sort((a, b) => a.value.localeCompare(b.value));
       }
 
       // Chart dimensions with responsive margins


### PR DESCRIPTION
## Summary
- Sort categorical bar chart bars alphabetically instead of by count descending
- Gives a stable, predictable x-axis order when categorical features contain numeric strings or other values that appear unordered today

Fixes #65