### PR TITLE
Fix dataset comparison Apply button overlapping chart controls

### DIFF
--- a/src/components/viz/VizSetup.tsx
+++ b/src/components/viz/VizSetup.tsx
@@ -164,7 +164,7 @@ const VizSetup = ({
           </div>
         )}
       </div>
-      <div className="flex-shrink-0 pt-3 pb-9">
+      <div className="flex-shrink-0 pt-3 pb-10">
         <button
           disabled={
             !gameDataIds.length ||


### PR DESCRIPTION
## Summary
- Increase pinned Apply footer padding in `VizSetup` so the button stays above the bottom-left chart control buttons at default 3-row chart heights
- Complements the scrollable settings layout shipped in #67, which prevents Apply from being pushed off-screen when dataset comparison fields and filter badges are shown

Fixes #64
