### PR TITLE
Move dashboard import button next to New Dashboard

### DIFF
--- a/src/components/sidebar/LayoutManager.tsx
+++ b/src/components/sidebar/LayoutManager.tsx
@@ -1,4 +1,4 @@
-import { Plus, Save, X, Pencil, Download } from 'lucide-react';
+import { Plus, Save, X, Pencil, Download, Upload } from 'lucide-react';
 import useLayoutStore, {
   DashboardLayoutWithMeta,
 } from '../../store/useLayoutStore';
@@ -7,7 +7,11 @@ import { useState } from 'react';
 import Input from '../layout/Input';
 import { trackEvent } from '../../lib/analytics';
 
-const LayoutManager = () => {
+type LayoutManagerProps = {
+  onImportClick: () => void;
+};
+
+const LayoutManager = ({ onImportClick }: LayoutManagerProps) => {
   const {
     layouts,
     currentLayout,
@@ -84,6 +88,13 @@ const LayoutManager = () => {
           >
             <Plus className="w-4 h-4 mr-2" />
             New Dashboard
+          </button>
+          <button
+            onClick={onImportClick}
+            className="max-w-sm inline-flex flex-1 items-center justify-center px-4 py-2 border-1 border-primary text-primary rounded-md font-medium cursor-pointer hover:bg-primary/5 transition-colors text-sm"
+          >
+            <Upload className="w-4 h-4 mr-2" />
+            Import Dashboard JSON
           </button>
         </div>
         {Object.entries(layouts).map(([id, layout]) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,6 @@ import CollapsibleSidePanel from '../components/sidebar/CollapsibleSidePanel';
 import LayoutManager from '../components/sidebar/LayoutManager';
 import TopBar from '../components/layout/TopBar';
 import DatasetDeepLinkProvider from '../components/providers/DatasetDeepLinkProvider';
-import { Upload } from 'lucide-react';
 import useDataStore from '../store/useDataStore';
 import useLayoutStore from '../store/useLayoutStore';
 import { trackEvent } from '../lib/analytics';
@@ -87,38 +86,27 @@ const HomePage: React.FC<HomePageProps> = ({ assistantEnabled }) => {
                     Dashboards
                   </button>
                 </nav>
-                <div className="flex items-center gap-2">
-                  <div className="flex flex-col gap-2">
-                    <label
-                      htmlFor="layout-data-store-json-file-upload"
-                      className="inline-flex items-center justify-center px-4 py-2 text-gray-500 rounded-md font-medium cursor-pointer hover:bg-gray-200 transition-colors text-sm"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        layoutDataStoreJsonFileInputRef.current?.click();
-                      }}
-                    >
-                      <Upload className="mr-2 h-4 w-4" />
-                      Import
-                    </label>
-                    <input
-                      id="layout-data-store-json-file-upload"
-                      ref={layoutDataStoreJsonFileInputRef}
-                      type="file"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (file && file.type === 'application/json') {
-                          handleImport(file);
-                        }
-                      }}
-                      className="hidden"
-                      accept="application/json"
-                    />
-                  </div>
-                </div>
               </div>
               <div className="mt-2 flex-1">
                 {activeTab === 0 && <DataSourceList />}
-                {activeTab === 1 && <LayoutManager />}
+                {activeTab === 1 && (
+                  <LayoutManager
+                    onImportClick={() => layoutDataStoreJsonFileInputRef.current?.click()}
+                  />
+                )}
+                <input
+                  id="layout-data-store-json-file-upload"
+                  ref={layoutDataStoreJsonFileInputRef}
+                  type="file"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file && file.type === 'application/json') {
+                      handleImport(file);
+                    }
+                  }}
+                  className="hidden"
+                  accept="application/json"
+                />
               </div>
             </div>
           </CollapsibleSidePanel>


### PR DESCRIPTION
## Summary
- Move the dashboard import action from the tab header into the Dashboards tab, placing it beside the `New Dashboard` button.
- Style the import button as an outlined primary action to match the TSV upload button pattern.
- Keep the existing JSON import behavior and hidden file input wiring unchanged.
