### PR TITLE
Fix filter dropdown scroll jump when selecting categories

### DIFF
--- a/src/components/layout/select/SearchableSelect.tsx
+++ b/src/components/layout/select/SearchableSelect.tsx
@@ -65,16 +65,21 @@ const SearchableSelect = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const prevIsOpenRef = useRef(false);
+
   useEffect(() => {
-    if (isOpen && scrollContainerRef.current) {
-      const selectedKey =
-        selectMultiple && Array.isArray(value) ? value[0] : (value as string);
-      if (selectedKey && selectedKey in filteredOptions) {
-        const selectedEl = Array.from(
-          scrollContainerRef.current.querySelectorAll('[data-value]'),
-        ).find((el) => el.getAttribute('data-value') === selectedKey);
-        selectedEl?.scrollIntoView({ block: 'nearest', behavior: 'auto' });
-      }
+    const justOpened = isOpen && !prevIsOpenRef.current;
+    prevIsOpenRef.current = isOpen;
+
+    if (!justOpened || !scrollContainerRef.current) return;
+
+    const selectedKey =
+      selectMultiple && Array.isArray(value) ? value[0] : (value as string);
+    if (selectedKey && selectedKey in filteredOptions) {
+      const selectedEl = Array.from(
+        scrollContainerRef.current.querySelectorAll('[data-value]'),
+      ).find((el) => el.getAttribute('data-value') === selectedKey);
+      selectedEl?.scrollIntoView({ block: 'nearest', behavior: 'auto' });
     }
   }, [isOpen, selectMultiple, value, filteredOptions]);
 


### PR DESCRIPTION
## Summary
- Fixes #70 by preventing `SearchableSelect` from auto-scrolling to the first selected item on every multi-select change
- Scroll-to-selection now runs only when the dropdown opens, so users can scroll through long category lists without the view jumping back up

## Test plan
- [ ] Open a bar chart with many categorical values
- [ ] Open **Categories to include**, scroll down, and select an item lower in the list
- [ ] Confirm the dropdown stays at the current scroll position
- [ ] Close and reopen the dropdown; confirm it still scrolls to the first selected item when opened
