### PR TITLE
Add collapsible Filters and Features sections under datasets

### DIFF
--- a/src/components/sidebar/data-management/DatasetFilter.tsx
+++ b/src/components/sidebar/data-management/DatasetFilter.tsx
@@ -2,12 +2,13 @@ import { useState, useMemo } from 'react';
 import SearchableSelect from '../../layout/select/SearchableSelect';
 import Input from '../../layout/Input';
 import useDataStore from '../../../store/useDataStore';
-import { X, Plus, Info } from 'lucide-react';
+import { X, Plus, Info, ChevronRight } from 'lucide-react';
 import * as d3 from 'd3';
 import FeatureSelect from '../../layout/select/FeatureSelect';
 
 export default function DatasetFilter({ dataset }: { dataset: GameData }) {
   const { addFilter, removeFilter, updateFilter } = useDataStore();
+  const [showFilters, setShowFilters] = useState(true);
   const [showAddFilter, setShowAddFilter] = useState(false);
 
   const handleAddFilter = () => {
@@ -24,15 +25,26 @@ export default function DatasetFilter({ dataset }: { dataset: GameData }) {
 
   return (
     <div className="space-y-3 mb-3">
-      <div className="font-bold text-sm text-gray-800 px-3 pt-2">
-        Filters
-        {Object.keys(dataset.filters ?? {}).length > 0 && (
-          <span className="ml-2 text-xs text-gray-500 font-normal">
-            ({Object.keys(dataset.filters ?? {}).length} applied)
-          </span>
-        )}
-      </div>
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 pt-2 text-left font-bold text-sm text-gray-800"
+        onClick={() => setShowFilters(!showFilters)}
+        aria-expanded={showFilters}
+      >
+        <ChevronRight
+          className={`w-4 h-4 shrink-0 hover:text-primary transition-colors transition-transform duration-100 ${showFilters && 'rotate-90'}`}
+        />
+        <span>
+          Filters
+          {Object.keys(dataset.filters ?? {}).length > 0 && (
+            <span className="ml-2 text-xs text-gray-500 font-normal">
+              ({Object.keys(dataset.filters ?? {}).length} applied)
+            </span>
+          )}
+        </span>
+      </button>
 
+      {showFilters && (
       <div className="px-3 space-y-3">
         {Object.entries(dataset.filters ?? {}).map(([feature, filter]) => (
           <FilterItem
@@ -66,6 +78,7 @@ export default function DatasetFilter({ dataset }: { dataset: GameData }) {
           </button>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/sidebar/data-management/DatasetItem.tsx
+++ b/src/components/sidebar/data-management/DatasetItem.tsx
@@ -131,6 +131,7 @@ const DatasetItem = ({ dataset, onSplit, onRemove }: DatasetItemProps) => {
 
   const ItemDetails = () => {
     const [searchFeature, setSearchFeature] = useState('');
+    const [showFeatures, setShowFeatures] = useState(true);
     return (
       <div className="w-full mt-2 px-4">
         <hr className="border-gray-200 my-2" />
@@ -138,7 +139,19 @@ const DatasetItem = ({ dataset, onSplit, onRemove }: DatasetItemProps) => {
         <DatasetFilter dataset={dataset} />
 
         <hr className="border-gray-200 my-2" />
-        <div className="font-bold text-sm text-gray-800 p-2">Features</div>
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 p-2 text-left font-bold text-sm text-gray-800"
+          onClick={() => setShowFeatures(!showFeatures)}
+          aria-expanded={showFeatures}
+        >
+          <ChevronRight
+            className={`w-4 h-4 shrink-0 hover:text-primary transition-colors transition-transform duration-100 ${showFeatures && 'rotate-90'}`}
+          />
+          Features
+        </button>
+        {showFeatures && (
+        <>
         <div className="px-1 pb-2">
           <Input
             placeholder="Search..."
@@ -190,6 +203,8 @@ const DatasetItem = ({ dataset, onSplit, onRemove }: DatasetItemProps) => {
               ),
             )}
         </div>
+        </>
+        )}
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- Add collapsible **Filters** section in `DatasetFilter` with a rotatable chevron trigger.
- Add collapsible **Features** section in `DatasetItem` with the same chevron interaction pattern used at the dataset level.
- Both sections default to expanded and include `aria-expanded` for accessibility.

Closes #76

## Test plan
- [ ] Expand a dataset in the sidebar data panel.
- [ ] Click the **Filters** chevron and confirm the filter list and Add Filter button collapse/expand with rotation.
- [ ] Click the **Features** chevron and confirm the search input and feature list collapse/expand with rotation.
- [ ] Verify both sections start expanded when opening dataset details.